### PR TITLE
Switch File.OpenWrite to File.Create

### DIFF
--- a/pick-a-browser/Config/AppData.cs
+++ b/pick-a-browser/Config/AppData.cs
@@ -51,7 +51,8 @@ namespace pick_a_browser.Config
             if (path != null)
                 Directory.CreateDirectory(path);
 
-            using (var stream = File.OpenWrite(filename))
+
+            using (var stream = File.Create(filename))
                 await JsonSerializer.SerializeAsync(stream, appData);
         }
     }

--- a/pick-a-browser/Updater.cs
+++ b/pick-a-browser/Updater.cs
@@ -119,7 +119,7 @@ namespace pick_a_browser
 
             statusUpdater?.Invoke("Downloading new release...");
             using (var stream = await client.GetStreamAsync(asset.DownloadUrl, cancellationToken))
-            using (var fileStream = File.OpenWrite(tmpExePath))
+            using (var fileStream = File.Create(tmpExePath))
             {
                 await CopyToWithProgress(stream, fileStream, statusUpdater, cancellationToken);
             }


### PR DESCRIPTION
Create truncates the file, avoiding any issues if the previous content was longer

Fixes #21 