### PR TITLE
Display version number in UI and prevent window resizing

### DIFF
--- a/pick-a-browser/BrowserScanWindow.xaml
+++ b/pick-a-browser/BrowserScanWindow.xaml
@@ -5,7 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:pick_a_browser"
         mc:Ignorable="d"
-        Title="Browser Scan..." Height="450" Width="800">
+        Title="Browser Scan..." Height="450" Width="800"
+        ResizeMode="NoResize">
     <Grid>
         <TextBox x:Name="browserContent" HorizontalAlignment="Stretch" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Stretch" Width="780" Height="414" />
 

--- a/pick-a-browser/LoadingWindow.xaml
+++ b/pick-a-browser/LoadingWindow.xaml
@@ -7,7 +7,8 @@
         d:DataContext="{d:DesignInstance Type=local:DesignTimeLoadingViewModel, IsDesignTimeCreatable=True}"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
-        Title="Processing URL..." Height="Auto" Width="400" Topmost="True">
+        Title="Processing URL..." Height="Auto" Width="400" Topmost="True"
+        ResizeMode="NoResize">
     <Grid>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Stretch" Margin="5 10 5 10" >
             <TextBlock Margin="0 0 5 0">URL:</TextBlock>

--- a/pick-a-browser/MainWindow.xaml
+++ b/pick-a-browser/MainWindow.xaml
@@ -5,7 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:pick_a_browser"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        Title="MainWindow" Height="450" Width="800"
+        ResizeMode="NoResize">
     <Grid>
 
     </Grid>

--- a/pick-a-browser/PickABrowserWindow.xaml
+++ b/pick-a-browser/PickABrowserWindow.xaml
@@ -52,7 +52,7 @@
         <StackPanel Grid.Row="2" Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 10 5 10" >
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <TextBlock Margin="0 0 5 0" Foreground="Black">Version:</TextBlock>
-                <TextBlock Text="{Binding InformationalVersion}" Foreground="Black" />
+                <TextBlock Text="{Binding Version}" Foreground="Black" />
             </StackPanel>
             <TextBlock Margin="0 0 5 0" 
                        Visibility="{Binding UpdateAvailableVisibility}">

--- a/pick-a-browser/PickABrowserWindow.xaml
+++ b/pick-a-browser/PickABrowserWindow.xaml
@@ -10,7 +10,8 @@
         Title="Choose browser..." Height="Auto" Width="400"
         SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        ResizeMode="NoResize">
 
     <Grid Background="#FFFFFFFF">
         <Grid.RowDefinitions>

--- a/pick-a-browser/UpdateWindow.xaml
+++ b/pick-a-browser/UpdateWindow.xaml
@@ -6,7 +6,8 @@
         xmlns:local="clr-namespace:pick_a_browser"
         d:DataContext="{d:DesignInstance Type=local:DesignTimeUpdateViewModel, IsDesignTimeCreatable=True}"
         mc:Ignorable="d"
-        Title="Update pick-a-browser..." Height="450" Width="800" Loaded="Window_Loaded" Closing="Window_Closing" KeyDown="Window_KeyDown">
+        Title="Update pick-a-browser..." Height="450" Width="800" Loaded="Window_Loaded" Closing="Window_Closing" KeyDown="Window_KeyDown"
+        ResizeMode="NoResize">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
Rather than display the verbose information version number (containing sha), show just the version number instead

![image](https://user-images.githubusercontent.com/1678318/149837939-e83d86a4-9623-400a-830a-f8da0922fdf9.png)

eg:

![image](https://user-images.githubusercontent.com/1678318/149838025-d6197518-d9ee-4434-816c-57d9fe15cbac.png)

The product version number can still be used to determine updates..

![image](https://user-images.githubusercontent.com/1678318/149837995-2c4370a0-44f5-4804-a859-73c38de89b7c.png)

